### PR TITLE
fix: use name of comment for identifying the comment to update

### DIFF
--- a/src/__tests__/comment_test.js
+++ b/src/__tests__/comment_test.js
@@ -10,6 +10,11 @@ describe("commentIdentifier", () => {
 		const result = commentIdentifier("workflow name")
 		expect(result).toEqual("<!-- Code Coverage Comment: workflow name -->")
 	})
+
+	test("a comment identifier is returned with a test name", function() {
+		const result = commentIdentifier("workflow name", "test name")
+		expect(result).toEqual("<!-- Code Coverage Comment: workflow name/test name -->")
+	})
 })
 
 describe("diff", () => {

--- a/src/comment.js
+++ b/src/comment.js
@@ -29,11 +29,14 @@ function comment(lcov, table, options) {
 		table,
 		"\n\n",
 		details(summary("Coverage Report"), tabulate(lcov, options)),
-		commentIdentifier(options.workflowName),
+		commentIdentifier(options.workflowName, options.name),
 	)
 }
 
-export function commentIdentifier(workflowName) {
+export function commentIdentifier(workflowName, name) {
+	if (name) {
+		return `<!-- Code Coverage Comment: ${workflowName}/${name} -->`
+	}
 	return `<!-- Code Coverage Comment: ${workflowName} -->`
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ async function main() {
 		})
 
 		const existingComment = issueComments.data.find(comment =>
-			comment.body.includes(commentIdentifier(options.workflowName)),
+			comment.body.includes(commentIdentifier(options.workflowName, options.name)),
 		)
 
 		if (existingComment) {


### PR DESCRIPTION
if only the workflow name is used, multiple actions in one workflwo would overwrite each other.